### PR TITLE
Update

### DIFF
--- a/src/vaults/apys/implementations/sushi-plus-native.js
+++ b/src/vaults/apys/implementations/sushi-plus-native.js
@@ -4,8 +4,10 @@ const { getApy: getSushiAPY } = require('./sushi.js')
 const { getApy: getSushiHODLApy } = require('./native-sushi.js')
 
 const getApy = async (...params) => {
-  let yearlyApr = await getSushiAPY(...params)
-  yearlyApr = new BigNumber(yearlyApr).plus(await getSushiHODLApy()).toString()
+  let sushiApr = new BigNumber(await getSushiAPY(...params))
+  let hodlApr = new BigNumber(await getSushiHODLApy())
+  let hodlApy = new BigNumber(hodlApr.div(36500).plus(1).pow(365).minus(1).times(100))
+  yearlyApr = sushiApr.times(hodlApy).div(2).div(hodlApr.div(2)).toFixed(2,1)
   return yearlyApr
 }
 


### PR DESCRIPTION
Fixed Sushi HODL apy. For some reason the HODL vault APY was simply added to the native vault APY. This gave very wrong numbers. I found a relation for APY in the case where rewards come in at some APR, and those rewards are compounded at some other APY. Like is the case for these hodl vaults. I implemented this relation:

`APY = (nativeAPR * hodlAPY/2)/(hodlAPR/2)`
So nativeAPR is the Sushi reward APR, hodlAPR is the sushiHodlVault APR and the hodlAPY is taken from the hodlAPR using daily compounding.

Also the settings on the hodl vaults need to be updated to show that a 15% fee is taken, so a 0.85 reduction value:
![image](https://user-images.githubusercontent.com/34768229/132662778-f90e0d26-e3e9-46a4-99ee-38bb20c777d7.png)

