### PR TITLE
Updated Idle vault apy calculation

### DIFF
--- a/src/lib/web3/contracts/idle-lending-token/methods.js
+++ b/src/lib/web3/contracts/idle-lending-token/methods.js
@@ -3,7 +3,10 @@ const getVirtualPrice = instance => countFunctionCall(instance.methods.tokenPric
 
 const getTotalSupply = instance => countFunctionCall(instance.methods.totalSupply().call())
 
+const getAvgAPR = instance => countFunctionCall(instance.methods.getAvgAPR().call())
+
 module.exports = {
   getVirtualPrice,
   getTotalSupply,
+  getAvgAPR,
 }

--- a/src/vaults/apys/implementations/idle-finance.js
+++ b/src/vaults/apys/implementations/idle-finance.js
@@ -33,7 +33,6 @@ const getIDLEPriceFromUniswapInWethWeis = async () => {
 const getApy = async (
   tokenSymbol,
   idleLendingTokenAddress,
-  compoundTokenAddress,
   isBtcLike,
   factor,
   lendApyOverride,
@@ -55,7 +54,7 @@ const getApy = async (
   } = idleController
 
   const {
-    methods: { getTotalSupply, getVirtualPrice },
+    methods: { getTotalSupply, getVirtualPrice, getAvgAPR },
     contract: { abi: idleLendingTokenAbi },
   } = idleLendingToken
 
@@ -93,14 +92,18 @@ const getApy = async (
   if (isBtcLike) {
     basicApy = basicApy.dividedBy(await getTokenPrice(tokenAddresses.WBTC))
   }
+  console.log("Basic apy:", basicApy.toFixed());
 
   const lendApy = lendApyOverride
     ? lendApyOverride
-    : await getCompoundAPY(compoundTokenAddress, false)
+    : new BigNumber(await getAvgAPR(idleLendingTokenInstance)).div(1e18)
+
+  console.log("Lend apy:", lendApy.toFixed());
 
   const result = basicApy.multipliedBy(factor).plus(lendApy).toString()
 
   cache.set(`idleApy${tokenSymbol}`, result)
+  console.log("Total apy:", result);
   return result
 }
 


### PR DESCRIPTION
Saw Idle vault apy was not very accurate. Updated the lending apy to be taken from the Idle token, which gives an average APR of all the platforms it is farming weighted to the distribution. This includes the governance token rewards like Compound and stkAave. I found this to give more accurate results than the older way taking Compound lending APY. 

Even more accurate would be a split between the lending apys and token apys, as we take 30% profit share also on the Compound/stkAave rewards, which is now not accounted for. For the stables this is not a huge problem as generally distribution apy is a small part compared to lending apy. For wbtc however nearly all returns are distribution apy.