### PR TITLE
Remove console.logs

### DIFF
--- a/src/vaults/apys/implementations/idle-finance.js
+++ b/src/vaults/apys/implementations/idle-finance.js
@@ -85,18 +85,14 @@ const getApy = async (tokenSymbol, idleLendingTokenAddress, isBtcLike, factor, l
   if (isBtcLike) {
     basicApy = basicApy.dividedBy(await getTokenPrice(tokenAddresses.WBTC))
   }
-  console.log('Basic apy:', basicApy.toFixed())
 
   const lendApy = lendApyOverride
     ? lendApyOverride
     : new BigNumber(await getAvgAPR(idleLendingTokenInstance)).div(1e18)
 
-  console.log('Lend apy:', lendApy.toFixed())
-
   const result = basicApy.multipliedBy(factor).plus(lendApy).toString()
 
   cache.set(`idleApy${tokenSymbol}`, result)
-  console.log('Total apy:', result)
   return result
 }
 


### PR DESCRIPTION
Removed console.logs from idle-finance implementation.

The `tokens.json` file needs to be updated for all tokens using this implementation. The `cToken` address was removed from the inputs. 

Before:
![image](https://user-images.githubusercontent.com/34768229/133229461-6772addd-b32b-435b-92bd-942604de0f79.png)

After:
![image](https://user-images.githubusercontent.com/34768229/133229540-a959aa8a-56ce-4950-b797-b9581f0f77ea.png)

With these changes all the tests run perfectly for me locally. I am not 100% sure about the CI, on my forked repo the CI tests are giving errors about the Infura keys that I am not sure how to fix.