### PR TITLE
Update to allow variable SUSHI vault strategy

### DIFF
--- a/src/vaults/apys/implementations/sushi-plus-native.js
+++ b/src/vaults/apys/implementations/sushi-plus-native.js
@@ -1,11 +1,19 @@
 const BigNumber = require('bignumber.js')
 
 const { getApy: getSushiAPY } = require('./sushi.js')
-const { getApy: getSushiHODLApy } = require('./native-sushi.js')
+const { UI_DATA_FILES } = require('../../../lib/constants')
+const { getUIData } = require('../../../lib/data')
+const { executeEstimateApyFunctions } = require('..')
 
 const getApy = async (...params) => {
+  const tokens = await getUIData(UI_DATA_FILES.TOKENS)
   let sushiApr = new BigNumber(await getSushiAPY(...params))
-  let hodlApr = new BigNumber(await getSushiHODLApy())
+  const hodlVaultData = tokens['SUSHI_HODL']
+  const { estimatedApy } = await executeEstimateApyFunctions(
+    'SUSHI_HODL',
+    hodlVaultData.estimateApyFunctions,
+  )
+  let hodlApr = new BigNumber(estimatedApy)
   let hodlApy = new BigNumber(hodlApr.div(36500).plus(1).pow(365).minus(1).times(100))
   let yearlyApr = sushiApr.times(hodlApy).div(2).div(hodlApr.div(2)).toFixed(2, 1)
   return yearlyApr


### PR DESCRIPTION
This update will keep the APY for the LP HODL vaults accurate when the Sushi vault is on a different strategy than simply hodling through xSushi/aave.