### PR TITLE
Ifarm price

### DIFF
--- a/data/mainnet/pools.js
+++ b/data/mainnet/pools.js
@@ -4441,6 +4441,10 @@ module.exports = [
  `,
   },
   {
+    tradingApyFunction: {
+      type: TRADING_APY_TYPES.LP,
+      params: [addresses.V2.sushi_YEL_ETH.Underlying],
+    },
     chain: CHAINS_ID.ETH_MAINNET,
     id: 'sushi_YEL_ETH',
     type: POOL_TYPES.INCENTIVE,

--- a/data/mainnet/tokens.js
+++ b/data/mainnet/tokens.js
@@ -262,7 +262,7 @@ module.exports = {
     tokenAddress: addresses.MATIC.miFARM,
     displayName: 'miFARM',
     vaultAddress: null,
-    priceFunction: { type: GET_PRICE_TYPES.COINGECKO_CONTRACT, params: [addresses.FARM] },
+    priceFunction: { type: GET_PRICE_TYPES.F_TOKEN, params: [addresses.iFARM, '18'] },
   },
   QUICK: {
     chain: CHAINS_ID.MATIC_MAINNET,
@@ -2388,8 +2388,8 @@ module.exports = {
     decimals: '18',
     vaultAddress: addresses.iFARM,
     priceFunction: {
-      type: GET_PRICE_TYPES.COINGECKO_CONTRACT,
-      params: [addresses.iFARM],
+      type: GET_PRICE_TYPES.F_TOKEN,
+      params: [addresses.iFARM, '18'],
     },
     estimateApyFunctions: [
       {

--- a/src/prices/implementations/f-token.js
+++ b/src/prices/implementations/f-token.js
@@ -27,7 +27,10 @@ const getPrice = async (tokenAddress, tokenDecimals) => {
   const web3Instance = getWeb3(chain)
   const fTokenVaultInstance = new web3Instance.eth.Contract(vaultAbi, tokenAddress)
 
-  const tokenSymbol = Object.keys(tokens).find(token => tokens[token].vaultAddress === tokenAddress)
+  let tokenSymbol = Object.keys(tokens).find(token => tokens[token].vaultAddress === tokenAddress)
+  if (tokenSymbol == 'IFARM') {
+    tokenSymbol = 'FARM'
+  }
 
   const underlyingTokenPrice = new BigNumber(await getTokenPrice(tokenSymbol))
 


### PR DESCRIPTION
Update iFARM price calculation. Noticed some numbers were off, reason is iFARM price on coingecko comes from the liquidity on Polygon which is often inaccurate, using `FARM price * sharePrice` is more accurate. Differences get as large as 10% in the last few days.

On Matic the iFARM price was even taken as simply the FARM price, which is selling ourselves short on the displayed rewards by ~20%.
