### PR TITLE
Update bal emission numbers

### DIFF
--- a/data/mainnet/tokens.js
+++ b/data/mainnet/tokens.js
@@ -525,7 +525,7 @@ module.exports = {
         params: [
           addresses.V2.bal_BAL_WETH.Underlying,
           addresses.V2.bal_BAL_WETH.PoolId,
-          '32000',
+          '30000',
           strat30PercentFactor,
           CHAINS_ID.ETH_MAINNET,
         ],
@@ -591,7 +591,7 @@ module.exports = {
         params: [
           addresses.V2.bal_USDC_WETH.Underlying,
           addresses.V2.bal_USDC_WETH.PoolId,
-          '5000',
+          '1100',
           strat30PercentFactor,
           CHAINS_ID.ETH_MAINNET,
         ],
@@ -624,7 +624,7 @@ module.exports = {
         params: [
           addresses.V2.bal_USDT_WETH.Underlying,
           addresses.V2.bal_USDT_WETH.PoolId,
-          '5000',
+          '120',
           strat30PercentFactor,
           CHAINS_ID.ETH_MAINNET,
         ],


### PR DESCRIPTION
BAL emissions on the ETH-USDC and ETH-USDT pools were reduced. Updated the numbers as I found them in: [https://docs.google.com/spreadsheets/u/1/d/e/2PACX-1vSZKosmjNMJkxC8xH8mSeXpoc0TNk0hFCdKcZ4mLq5vk5grWIv9kWUyUjP2I94KOUPUoL521F0qxyN0/pubhtml?gid=643569366&single=true](https://docs.google.com/spreadsheets/u/1/d/e/2PACX-1vSZKosmjNMJkxC8xH8mSeXpoc0TNk0hFCdKcZ4mLq5vk5grWIv9kWUyUjP2I94KOUPUoL521F0qxyN0/pubhtml?gid=643569366&single=true)

Also someone noticed the BAL rewards are not displaying the tooltips on the Polygon page. Running tests on the API repo I can see that the BAL apys are calculated correctly. I do not know why they are not displayed.