### PR TITLE
Remove 'onlyProfit' from crvBUSD

### DIFF
--- a/data/mainnet/addresses.json
+++ b/data/mainnet/addresses.json
@@ -342,8 +342,7 @@
     "crvBUSD": {
       "NewVault": "0x4b1cBD6F6D8676AcE5E412C78B7a59b4A1bbb68a",
       "NewStrategy": "0x2b7CAA7D87c01152A82c266791AdA69CcFe64045",
-      "NewPool": "0x093C2ae5E6F3D2A897459aa24551289D462449AD",
-      "doHardwork": "onlyProfit"
+      "NewPool": "0x093C2ae5E6F3D2A897459aa24551289D462449AD"
     },
     "sushi_PERP_ETH": {
       "Underlying": "0x8486c538DcBD6A707c5b3f730B6413286FE8c854",
@@ -1454,7 +1453,7 @@
   "MATIC": {
     "miFARM": "0xab0b2ddB9C7e440fAc8E140A89c0dbCBf2d7Bbff",
     "dQUICK": "0xf28164a485b0b2c90639e47b0f377b4a438a16b1",
-    "QUICK": "0x831753dd7087cac61ab5644b308642cc1c33dc13",    
+    "QUICK": "0x831753dd7087cac61ab5644b308642cc1c33dc13",
     "pUSDT": "0xc2132d05d31c914a87c6611c10748aeb04b58e8f",
     "pWETH": "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619",
     "pUSDC": "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",


### PR DESCRIPTION
crvBUSD is on `onlyProfit`, which is inconsistent with the other Curve pools with similar TVL and APY. The vault has not been harvested for nearly 3 weeks, which raised questions in the Discord. I think we should have it harvested at least weekly if we present it as active in the UI, so I removed the setting.