### PR TITLE
Update to token price implementation through UniV3

### DIFF
--- a/src/prices/implementations/uniswap-v3.js
+++ b/src/prices/implementations/uniswap-v3.js
@@ -17,6 +17,8 @@ const uniVaultStorageContractData = require('../../lib/web3/contracts/univault-s
 const { getStorage } = require('../../lib/web3/contracts/uniswap-v3/methods')
 const { getPosId: getUniV3PosId } = require('../../lib/web3/contracts/univault-storage/methods')
 
+const { getTokenPrice } = require('..')
+
 const getPrice = async (firstToken, secondToken, fee = 500, chainId = 1) => {
   const tokens = await getUIData(UI_DATA_FILES.TOKENS)
   const firstTokenData = tokens[firstToken]
@@ -53,9 +55,16 @@ const getPrice = async (firstToken, secondToken, fee = 500, chainId = 1) => {
     Number(univ3PoolSlotData.tick),
   )
 
-  return new Fraction(priceData.numerator, priceData.denominator)
+  let price = new Fraction(priceData.numerator, priceData.denominator)
     .multiply(priceData.scalar)
     .toFixed(7)
+
+  if (secondToken == 'WETH') {
+    const ethPrice = await getTokenPrice('WETH')
+    price = price * ethPrice
+  }
+
+  return price
 }
 
 const getPosId = async (contractAddress, web3Instance) => {


### PR DESCRIPTION
Update to UniV3 price implementation to automatically convert price to USD when output token is WETH. It is needed to get an accurate price for CNG.