### PR TITLE
Update YEL-ETH apy display

### DIFF
--- a/data/mainnet/pools.js
+++ b/data/mainnet/pools.js
@@ -4851,7 +4851,7 @@ module.exports = [
     contractAddress: addresses.V2.sushi_YEL_ETH.NewPool,
     collateralAddress: addresses.V2.sushi_YEL_ETH.NewVault,
     rewardAPY: [],
-    rewardTokens: [addresses.iFARM, addresses.V2.yelhold_YEL.NewVault],
+    rewardTokens: [addresses.iFARM],
     rewardTokenSymbols: ['iFARM', 'fYEL'],
     stakeAndDepositHelpMessage: `
       <div class="help-message">

--- a/data/mainnet/tokens.js
+++ b/data/mainnet/tokens.js
@@ -320,9 +320,14 @@ module.exports = {
     },
     estimateApyFunctions: [
       {
+        type: 'YEL',
+        params: [
+          addresses.V2.sushi_YEL_ETH.PoolId,
+          strat30PercentFactor,
+          addresses.V2.yelhold_YEL.PoolId,
+          strat30PercentFactor,
+        ],
         extraDailyCompound: false,
-        type: ESTIMATED_APY_TYPES.MANUAL,
-        params: ['0.00'],
       },
     ],
     cmcRewardTokenSymbols: ['iFARM', 'YEL', 'ETH'],

--- a/src/vaults/apys/implementations/yel.js
+++ b/src/vaults/apys/implementations/yel.js
@@ -23,7 +23,7 @@ const getApy = async (poolId, reduction, hodlPoolId, hodlReduction) => {
     let baseApr = await getPoolApy(poolId, reduction)
     let hodlApr = await getPoolApy(hodlPoolId, hodlReduction)
     let hodlApy = ((hodlApr / 100 / 365 + 1) ** 365 - 1) * 100
-    return (baseApr * hodlApy / 2) / (hodlApr / 2)
+    return (baseApr * hodlApy) / 2 / (hodlApr / 2)
   }
 }
 

--- a/src/vaults/apys/implementations/yel.js
+++ b/src/vaults/apys/implementations/yel.js
@@ -23,7 +23,7 @@ const getApy = async (poolId, reduction, hodlPoolId, hodlReduction) => {
     let baseApr = await getPoolApy(poolId, reduction)
     let hodlApr = await getPoolApy(hodlPoolId, hodlReduction)
     let hodlApy = ((hodlApr / 100 / 365 + 1) ** 365 - 1) * 100
-    return (baseApr * hodlApy) / 2 / (hodlApr / 2)
+    return (baseApr * hodlApy / 2) / (hodlApr / 2)
   }
 }
 


### PR DESCRIPTION
Currently APY is overestimated as it takes the fYEL rewards earning through the PotPool and then assumes compounding of these fYEL rewards. With this update the APY is based on the APR earned by the YEL-ETH LP and then depositing these rewards into the fYEL vault, where it gets compounded with the fYEL APY. Also with this update APY will not be impacted with the vault TVL as much.