### PR TITLE
Add Polygon IDLE vaults to UI

### DIFF
--- a/data/constants.js
+++ b/data/constants.js
@@ -26,6 +26,7 @@ const VAULT_CATEGORIES_IDS = {
   JARVIS: 'JARVIS',
   AMPLIFARM: 'AMPLIFARM',
   QUICKSWAP: 'QUICKSWAP',
+  IDLE: 'IDLE',
 }
 
 const VAULT_CATEGORIES_NAMES = {
@@ -56,6 +57,7 @@ const VAULT_CATEGORIES_NAMES = {
   JARVIS: 'Jarvis',
   AMPLIFARM: 'AmpliFarm',
   QUICKSWAP: 'Quickswap',
+  IDLE: 'IDLE',
 }
 
 const CHAINS_ID = {

--- a/data/mainnet/addresses.json
+++ b/data/mainnet/addresses.json
@@ -1616,6 +1616,27 @@
       "StrategyContract": "JarvisHodlStrategyMainnet_jGBP_USDC",
       "NewStrategy": "0xB60E69F21b469A93aB6e3f4a831E833bcFb7C7dE",
       "NewPool": "0xB91f62A423dE007ce25E5538D747B259fb207938"
+    },
+    "polygon_DAI": {
+    "Underlying": "0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063",
+    "NewVault": "0x2Fee56e039AcCceFA3cB1f3051aD00fe550a472c",
+    "StrategyContract": "IdleStrategyDAIMainnet",
+    "NewStrategy": "0x3330d534A470BdaBD1105dab6C5Fa61E7789882E",
+    "NewPool": "0x5954F9d5AFb005ebA67813B5Ab82398FAC7F0178"
+    },
+    "polygon_USDC": {
+      "Underlying": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+      "NewVault": "0xe7c9D242137896741b70CEfef701bBB4DcB158ec",
+      "StrategyContract": "IdleStrategyUSDCMainnet",
+      "NewStrategy": "0x08043b010AD2CD72db75878201FDE4B03e28e069",
+      "NewPool": "0xeA4Eca0FbeB0fcAaE61D2fA2B2877d435FAEee1C"
+    },
+    "polygon_WETH": {
+      "Underlying": "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619",
+      "NewVault": "0x9048A123Ae6C86a2B9fdC3eA28Ed1911DE8363A6",
+      "StrategyContract": "IdleStrategyWETHMainnet",
+      "NewStrategy": "0x7Ad709Df8B897B3b623C5413E92A6F70CA563e1d",
+      "NewPool": "0xEa2c3C25985fBB5418c61451C2cbD1311e0EbE9e"
     }
   }
 }

--- a/data/mainnet/pools.js
+++ b/data/mainnet/pools.js
@@ -5,6 +5,36 @@ const strat30PercentFactor = '0.7'
 
 module.exports = [
   {
+    chain: CHAINS_ID.MATIC_MAINNET,
+    id: 'polygon_WETH',
+    type: POOL_TYPES.INCENTIVE,
+    contractAddress: addresses.MATIC.polygon_WETH.NewPool,
+    collateralAddress: addresses.MATIC.polygon_WETH.NewVault,
+    rewardAPY: [],
+    rewardTokens: [addresses.MATIC.miFARM, addresses.MATIC.WMATIC],
+    rewardTokenSymbols: ['miFARM', 'WMATIC'],
+  },
+  {
+    chain: CHAINS_ID.MATIC_MAINNET,
+    id: 'polygon_USDC',
+    type: POOL_TYPES.INCENTIVE,
+    contractAddress: addresses.MATIC.polygon_USDC.NewPool,
+    collateralAddress: addresses.MATIC.polygon_USDC.NewVault,
+    rewardAPY: [],
+    rewardTokens: [addresses.MATIC.miFARM, addresses.MATIC.WMATIC],
+    rewardTokenSymbols: ['miFARM', 'WMATIC'],
+  },
+  {
+    chain: CHAINS_ID.MATIC_MAINNET,
+    id: 'polygon_DAI',
+    type: POOL_TYPES.INCENTIVE,
+    contractAddress: addresses.MATIC.polygon_DAI.NewPool,
+    collateralAddress: addresses.MATIC.polygon_DAI.NewVault,
+    rewardAPY: [],
+    rewardTokens: [addresses.MATIC.miFARM, addresses.MATIC.WMATIC],
+    rewardTokenSymbols: ['miFARM', 'WMATIC'],
+  },
+  {
     chain: CHAINS_ID.ETH_MAINNET,
     id: 'UniV3_USDC_ETH_4200_5500',
     tradingApyFunction: {

--- a/data/mainnet/tokens.js
+++ b/data/mainnet/tokens.js
@@ -10,8 +10,6 @@ const {
 
 const addresses = require('./addresses.json')
 
-const IDLE_WETH_V4 = '0xc8e6ca6e96a326dc448307a5fde90a0b21fd7f80'
-
 const strat30PercentFactor = '0.7'
 const profitSharingCut8Percent = '0.92'
 const convexProfitSharingFactor = '0.63'
@@ -42,7 +40,7 @@ module.exports = {
     estimateApyFunctions: [
       {
         type: ESTIMATED_APY_TYPES.IDLE_FINANCE,
-        params: ['WETH', IDLE_WETH_V4, false, '0.7'],
+        params: ['WETH', '0xc8e6ca6e96a326dc448307a5fde90a0b21fd7f80', '0.7'],
         extraDailyCompound: false,
       },
     ],
@@ -555,15 +553,33 @@ module.exports = {
     cmcRewardTokenSymbols: ['miFARM', 'pUSDC', 'pWETH'],
   },
   pWETH: {
+    category: VAULT_CATEGORIES_IDS.IDLE,
     chain: CHAINS_ID.MATIC_MAINNET,
+    isNew: true,
     logoUrl: './icons/weth.png',
-    tokenAddress: addresses.MATIC.pWETH,
+    apyIconUrls: ['./icons/wmatic.png'],
+    apyTokenSymbols: ['WMATIC'],
+    displayName: 'WETH',
+    subLabel: 'IDLE',
+    tokenAddress: addresses.MATIC.polygon_WETH.Underlying,
     decimals: '18',
-    vaultAddress: null,
+    vaultAddress: addresses.MATIC.polygon_WETH.NewVault,
     priceFunction: {
       type: GET_PRICE_TYPES.COINGECKO_CONTRACT,
       params: [addresses.WETH],
     },
+    estimateApyFunctions: [
+      {
+        type: ESTIMATED_APY_TYPES.IDLE_FINANCE,
+        params: [
+          'pWETH',
+          '0xfdA25D931258Df948ffecb66b5518299Df6527C4',
+          profitSharingCut8Percent,
+          CHAINS_ID.MATIC_MAINNET,
+        ],
+      },
+    ],
+    cmcRewardTokenSymbols: ['iFARM', 'wMATIC'],
   },
   pUSDT: {
     chain: CHAINS_ID.MATIC_MAINNET,
@@ -577,15 +593,62 @@ module.exports = {
     },
   },
   pUSDC: {
+    category: VAULT_CATEGORIES_IDS.IDLE,
     chain: CHAINS_ID.MATIC_MAINNET,
+    isNew: true,
     logoUrl: './icons/usdc.png',
-    tokenAddress: addresses.MATIC.pUSDC,
+    apyIconUrls: ['./icons/wmatic.png'],
+    apyTokenSymbols: ['WMATIC'],
+    displayName: 'USDC',
+    subLabel: 'IDLE',
+    tokenAddress: addresses.MATIC.polygon_USDC.Underlying,
     decimals: '6',
-    vaultAddress: null,
+    vaultAddress: addresses.MATIC.polygon_USDC.NewVault,
     priceFunction: {
       type: GET_PRICE_TYPES.COINGECKO_CONTRACT,
       params: [addresses.USDC],
     },
+    estimateApyFunctions: [
+      {
+        type: ESTIMATED_APY_TYPES.IDLE_FINANCE,
+        params: [
+          'pUSDC',
+          '0x1ee6470CD75D5686d0b2b90C0305Fa46fb0C89A1',
+          profitSharingCut8Percent,
+          CHAINS_ID.MATIC_MAINNET,
+        ],
+      },
+    ],
+    cmcRewardTokenSymbols: ['iFARM', 'wMATIC'],
+  },
+  pDAI: {
+    category: VAULT_CATEGORIES_IDS.IDLE,
+    chain: CHAINS_ID.MATIC_MAINNET,
+    isNew: true,
+    logoUrl: './icons/dai.png',
+    apyIconUrls: ['./icons/wmatic.png'],
+    apyTokenSymbols: ['WMATIC'],
+    displayName: 'DAI',
+    subLabel: 'IDLE',
+    tokenAddress: addresses.MATIC.polygon_DAI.Underlying,
+    decimals: '6',
+    vaultAddress: addresses.MATIC.polygon_DAI.NewVault,
+    priceFunction: {
+      type: GET_PRICE_TYPES.COINGECKO_CONTRACT,
+      params: [addresses.DAI],
+    },
+    estimateApyFunctions: [
+      {
+        type: ESTIMATED_APY_TYPES.IDLE_FINANCE,
+        params: [
+          'pDAI',
+          '0x8a999F5A3546F8243205b2c0eCb0627cC10003ab',
+          profitSharingCut8Percent,
+          CHAINS_ID.MATIC_MAINNET,
+        ],
+      },
+    ],
+    cmcRewardTokenSymbols: ['iFARM', 'wMATIC'],
   },
   miFARM: {
     chain: CHAINS_ID.MATIC_MAINNET,
@@ -1540,7 +1603,7 @@ module.exports = {
     estimateApyFunctions: [
       {
         type: ESTIMATED_APY_TYPES.IDLE_FINANCE,
-        params: ['USDC', '0x5274891bEC421B39D23760c04A6755eCB444797C', false, '0.7'],
+        params: ['USDC', '0x5274891bEC421B39D23760c04A6755eCB444797C', '0.7'],
       },
     ],
   },
@@ -1559,7 +1622,7 @@ module.exports = {
     estimateApyFunctions: [
       {
         type: ESTIMATED_APY_TYPES.IDLE_FINANCE,
-        params: ['DAI', '0x3fe7940616e5bc47b0775a0dccf6237893353bb4', false, '0.7'],
+        params: ['DAI', '0x3fe7940616e5bc47b0775a0dccf6237893353bb4', '0.7'],
       },
     ],
   },
@@ -1578,7 +1641,7 @@ module.exports = {
     estimateApyFunctions: [
       {
         type: ESTIMATED_APY_TYPES.IDLE_FINANCE,
-        params: ['USDT', '0xF34842d05A1c888Ca02769A633DF37177415C2f8', false, '0.7'],
+        params: ['USDT', '0xF34842d05A1c888Ca02769A633DF37177415C2f8', '0.7'],
       },
     ],
   },
@@ -1743,7 +1806,7 @@ module.exports = {
     estimateApyFunctions: [
       {
         type: ESTIMATED_APY_TYPES.IDLE_FINANCE,
-        params: ['WBTC', '0x8C81121B15197fA0eEaEE1DC75533419DcfD3151', true, '0.7'],
+        params: ['WBTC', '0x8C81121B15197fA0eEaEE1DC75533419DcfD3151', '0.7'],
       },
     ],
   },
@@ -4772,7 +4835,6 @@ module.exports = {
   jarvis_JEUR_USDC_HODL: {
     category: VAULT_CATEGORIES_IDS.JARVIS,
     chain: CHAINS_ID.MATIC_MAINNET,
-    isNew: true,
     logoUrl: './icons/eur-usdc.png',
     apyIconUrls: ['./icons/jaur.png'],
     apyTokenSymbols: ['AUR'],
@@ -4801,7 +4863,6 @@ module.exports = {
   jarvis_JGBP_USDC_HODL: {
     category: VAULT_CATEGORIES_IDS.JARVIS,
     chain: CHAINS_ID.MATIC_MAINNET,
-    isNew: true,
     logoUrl: './icons/gbp-usdc.png',
     apyIconUrls: ['./icons/jaur.png'],
     apyTokenSymbols: ['AUR'],
@@ -4830,7 +4891,6 @@ module.exports = {
   jarvis_JCHF_USDC_HODL: {
     category: VAULT_CATEGORIES_IDS.JARVIS,
     chain: CHAINS_ID.MATIC_MAINNET,
-    isNew: true,
     logoUrl: './icons/chf-usdc.png',
     apyIconUrls: ['./icons/jaur.png'],
     apyTokenSymbols: ['AUR'],
@@ -4859,7 +4919,6 @@ module.exports = {
   jarvis_AUR_USDC: {
     category: VAULT_CATEGORIES_IDS.JARVIS,
     chain: CHAINS_ID.MATIC_MAINNET,
-    isNew: true,
     logoUrl: './icons/aur-usdc.png',
     apyIconUrls: ['./icons/jaur.png'],
     apyTokenSymbols: ['AUR'],


### PR DESCRIPTION
Add IDLE vaults to UI. Small part of the APY, the extra wMatic rewards from IDLE are currently missing, but they are only a small part of the APY, which can be added later.

Something that might look a bit confusing is the fact that we are compounding wMATIC rewards, coming from Aave and IDLE and giving claimable wMATIC ourselves. So I think the wMATIC symbol will show twice with different rates, which is technically true.