### PR TITLE
Aur rewards ended

### DIFF
--- a/data/mainnet/tokens.js
+++ b/data/mainnet/tokens.js
@@ -5115,8 +5115,9 @@ module.exports = {
     },
     estimateApyFunctions: [
       {
-        type: 'JARVIS',
-        params: [3, addresses.MATIC.jarvis_AUR_USDC.Underlying, profitSharingCut8Percent],
+        extraDailyCompound: false,
+        type: ESTIMATED_APY_TYPES.MANUAL,
+        params: ['0.00'],
       },
     ],
     cmcRewardTokenSymbols: ['iFARM', 'AUR'],

--- a/src/vaults/apys/implementations/jarvis-hodl.js
+++ b/src/vaults/apys/implementations/jarvis-hodl.js
@@ -15,7 +15,12 @@ const getApy = async (...params) => {
   )
   let hodlApy = estimatedApy
   let hodlApr = new BigNumber((Math.pow(hodlApy / 100 + 1, 1 / 365) - 1) * 36500)
-  let yearlyApr = nativeApr.times(hodlApy).div(2).div(hodlApr.div(2)).toFixed(2, 1)
+  let yearlyApr
+  if (hodlApy == 0 || hodlApr == 0) {
+    yearlyApr = nativeApr.toFixed(2, 1)
+  } else {
+    yearlyApr = nativeApr.times(hodlApy.div(2)).div(hodlApr.div(2)).toFixed(2, 1)
+  }
   return yearlyApr
 }
 module.exports = {


### PR DESCRIPTION
AUR-USDC APY to 0, jFIAT pools can keep showing, as they are on rewardpools with a week duration, so rewards are still going for those. Soon these vaults will be updated with new strategies for the new AUR reward program.