### PR TITLE
round big number to fix not supported decimals

### DIFF
--- a/cron/polygon/standalone-runner.js
+++ b/cron/polygon/standalone-runner.js
@@ -183,7 +183,7 @@ async function getFeeData() {
   let fee = await axios
     .get('https://owlracle.info/poly/gas?accept=90&apikey=' + settings.owlracleApiKey)
     .then(response => {
-      return parseFloat(response.data.speeds[0].gasPrice) * 1e9
+      return Math.round(parseFloat(response.data.speeds[0].gasPrice) * 1e9)
     })
     .catch(error => {
       console.log(error)
@@ -196,7 +196,7 @@ async function getFeeData() {
     fee = settings.gasPriceMax
   }
 
-  let priorityFee = Math.ceil(fee / 3)
+  let priorityFee = Math.round(fee / 3)
   if (priorityFee > settings.priorityFeeMax) {
     priorityFee = settings.priorityFeeMax
   }

--- a/cron/polygon/standalone-runner.js
+++ b/cron/polygon/standalone-runner.js
@@ -196,7 +196,7 @@ async function getFeeData() {
     fee = settings.gasPriceMax
   }
 
-  let priorityFee = fee / 3
+  let priorityFee = Math.ceil(fee / 3)
   if (priorityFee > settings.priorityFeeMax) {
     priorityFee = settings.priorityFeeMax
   }


### PR DESCRIPTION
Should fix 
```
Error: Error: [number-to-bn] while converting number 44323021002.666664 to BN.js instance, error: invalid number value. Value must be an integer, hex string, BN or BigNumber instance. Note, decimals are not supported. Given value: "44323021002.666664"
```