### PR TITLE
increase maxPriorityFeePerGas to half of maxFeePerGas for Polygon cron bot

### DIFF
--- a/cron/polygon/standalone-runner.js
+++ b/cron/polygon/standalone-runner.js
@@ -196,7 +196,7 @@ async function getFeeData() {
     fee = settings.gasPriceMax
   }
 
-  let priorityFee = Math.round(fee / 3)
+  let priorityFee = Math.round(fee / 2)
   if (priorityFee > settings.priorityFeeMax) {
     priorityFee = settings.priorityFeeMax
   }


### PR DESCRIPTION
This setting has been tested for 2 days and works better when base fee is low.

Minimum `maxPriorityFeePerGas` 65 / 2 = 32.5
Maximum `maxPriorityFeePerGas` set in config.