### PR TITLE
Reactivate genomes

### DIFF
--- a/data/mainnet/tokens.js
+++ b/data/mainnet/tokens.js
@@ -1088,6 +1088,7 @@ module.exports = {
   },
   jarvis_AURJUL22_WETH: {
     category: VAULT_CATEGORIES_IDS.INACTIVE_POLYGON,
+    inactive: true,
     chain: CHAINS_ID.MATIC_MAINNET,
     logoUrl: './icons/aur-weth.png',
     apyIconUrls: [],

--- a/data/mainnet/tokens.js
+++ b/data/mainnet/tokens.js
@@ -2063,9 +2063,8 @@ module.exports = {
     },
   },
   SUSHI_GENE_ETH: {
-    inactive: true,
     chain: CHAINS_ID.MATIC_MAINNET,
-    category: VAULT_CATEGORIES_IDS.INACTIVE_POLYGON,
+    category: VAULT_CATEGORIES_IDS.GENOMES,
     logoUrl: './icons/sushi-gene-eth.png',
     subLabel: 'Genomes.io',
     apyIconUrls: [],
@@ -2087,9 +2086,8 @@ module.exports = {
     cmcRewardTokenSymbols: ['miFARM', 'pGNOME'],
   },
   SUSHI_GNOME_ETH: {
-    inactive: true,
     chain: CHAINS_ID.MATIC_MAINNET,
-    category: VAULT_CATEGORIES_IDS.INACTIVE_POLYGON,
+    category: VAULT_CATEGORIES_IDS.GENOMES,
     logoUrl: './icons/sushi-gnome-eth.png',
     subLabel: 'Genomes.io',
     apyIconUrls: [],


### PR DESCRIPTION
Reactivate Genomes vaults per their request.

A hack happened to a staking contract which Genomes operated. This caused a price dump for their tokens, but the security for the tokens themselves is not compromised and neither are our staking pools. They have taken action to recover the losses caused by the hack and have restored the market prices to pre-hack levels.

I think we are good to reactivate the vaults.